### PR TITLE
Improve build system and installation documentation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,6 +137,14 @@ else(DOXYGEN_FOUND)
 endif(DOXYGEN_FOUND)
 
 ########################################################################
+# Include or not into the module blocks for debugging
+########################################################################
+if(NOT INCLUDE_DEBUG_BLOCKS)
+	set(INCLUDE_DEBUG_BLOCKS OFF CACHE BOOL 
+	    "Disable blocks that are used for debugging purposes")
+endif()
+
+########################################################################
 # Setup the include and linker paths
 ########################################################################
 include_directories(

--- a/README.md
+++ b/README.md
@@ -24,6 +24,33 @@ for decoding signals from various scientific and academic sattelites.
 If this is the first time you are building the gr-satnogs module run
 `sudo ldconfig`
 
+#### Advanced
+By default, the **SatNOGS** module will use the default installation prefix.
+This highly depends on the Linux distribution. You can use the `CMAKE_INSTALL_PREFIX`
+variable to alter the default installation path.
+E.g: 
+
+`cmake -DCMAKE_INSTALL_PREFIX=/usr ..`
+
+Also, by default the build system disables a set of blocks used for debugging
+during the development. The enable/disable switch is controled through the 
+`INCLUDE_DEBUG_BLOCKS` boolean variable. If for example, you want to enable the
+debugging blocks, the **CMake** command would be:
+
+`cmake -DINCLUDE_DEBUG_BLOCKS=OFF ..`
+
+Another common control option is the library sugffix of the Linux distribution.
+There are distributions like Fedora, openSUSE, e.t.c that the their 64-bit version
+use the `lib64` folder to store the 64-bit versions of their dynamic libraries.
+On the other hand, distributions like Ubuntu do the exact opposite. They use
+`lib` directory for the libraries of the native architecture and place the 32-bit versions
+on the `lib32` directory. In any case the correct library directory suffix
+can be specified with the `LIB_SUFFIX` variable. For example:
+
+`cmake -DLIB_SUFFIX=64 -DCMAKE_INSTALL_PREFIX=/usr -DINCLUDE_DEBUG_BLOCKS=OFF ..`
+
+will install the libraries at the `/usr/lib64` directory.
+
 ## Website
 For more indormation about SatNOGS please visit our [site](https://satnogs.org/).
 

--- a/grc/CMakeLists.txt
+++ b/grc/CMakeLists.txt
@@ -16,15 +16,20 @@
 # along with GNU Radio; see the file COPYING.  If not, write to
 # the Free Software Foundation, Inc., 51 Franklin Street,
 # Boston, MA 02110-1301, USA.
-install(FILES
+
+list(APPEND debug_blocks
+	satnogs_morse_debug_source.xml
+	satnogs_debug_msg_source.xml
+	satnogs_debug_msg_source_raw.xml
+)
+
+list(APPEND enabled_blocks
     satnogs_cw_matched_filter_ff.xml
     satnogs_morse_decoder.xml
-    satnogs_morse_debug_source.xml
     satnogs_multi_format_msg_sink.xml
     satnogs_cw_to_symbol.xml
     satnogs_sine_matched_filter_ff.xml
     satnogs_udp_msg_source.xml
-    satnogs_debug_msg_source.xml
     satnogs_tcp_rigctl_msg_source.xml
     satnogs_frame_encoder.xml
     satnogs_doppler_correction_cc.xml
@@ -34,8 +39,16 @@ install(FILES
     satnogs_udp_msg_sink.xml
     satnogs_upsat_transmitter.xml
     satnogs_coarse_doppler_correction_cc.xml
-    satnogs_debug_msg_source_raw.xml
     satnogs_ax25_encoder_mb.xml
     satnogs_ax25_decoder_bm.xml
-    satnogs_qb50_deframer.xml DESTINATION share/gnuradio/grc/blocks
+    satnogs_qb50_deframer.xml
+)
+
+if(${INCLUDE_DEBUG_BLOCKS})
+	list(APPEND enabled_blocks ${debug_blocks})
+endif()
+
+install(FILES
+	${enabled_blocks}
+	DESTINATION share/gnuradio/grc/blocks
 )

--- a/include/satnogs/CMakeLists.txt
+++ b/include/satnogs/CMakeLists.txt
@@ -20,7 +20,13 @@
 ########################################################################
 # Install public header files
 ########################################################################
-install(FILES
+list(APPEND DEBUG_HEADER_FILES
+	morse_debug_source.h
+	debug_msg_source_raw.h
+	debug_msg_source.h
+)
+
+list(APPEND HEADER_FILES
     api.h
     ax25.h
     config.h
@@ -29,13 +35,11 @@ install(FILES
     morse_tree.h
     morse.h
     morse_decoder.h
-    morse_debug_source.h
     multi_format_msg_sink.h
     cw_to_symbol.h
     sine_matched_filter_ff.h
     utils.h
     udp_msg_source.h
-    debug_msg_source.h
     tcp_rigctl_msg_source.h
     frame_encoder.h
     doppler_correction_cc.h
@@ -46,8 +50,16 @@ install(FILES
     whitening.h
     udp_msg_sink.h
     coarse_doppler_correction_cc.h
-    debug_msg_source_raw.h
     ax25_encoder_mb.h
     ax25_decoder_bm.h
-    qb50_deframer.h DESTINATION include/satnogs
+    qb50_deframer.h
+)
+
+if(${INCLUDE_DEBUG_BLOCKS})
+	list(APPEND HEADER_FILES ${DEBUG_HEADER_FILES})
+endif()
+
+install(FILES
+	${HEADER_FILES}
+	DESTINATION include/satnogs
 )

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -24,16 +24,21 @@ include(GrPlatform) #define LIB_SUFFIX
 
 include_directories(${Boost_INCLUDE_DIR})
 link_directories(${Boost_LIBRARY_DIRS})
+
+list(APPEND satnogs_debug_sources
+	morse_debug_source_impl.cc
+	debug_msg_source_impl.cc
+	debug_msg_source_raw_impl.cc
+)
+
 list(APPEND satnogs_sources
     cw_matched_filter_ff_impl.cc
     morse_tree.cc
     morse_decoder_impl.cc
-    morse_debug_source_impl.cc
     multi_format_msg_sink_impl.cc
     cw_to_symbol_impl.cc
     sine_matched_filter_ff_impl.cc
     udp_msg_source_impl.cc
-    debug_msg_source_impl.cc
     tcp_rigctl_msg_source_impl.cc
     doppler_correction_cc_impl.cc
     frame_encoder_impl.cc
@@ -44,10 +49,13 @@ list(APPEND satnogs_sources
     whitening.cc
     udp_msg_sink_impl.cc
     coarse_doppler_correction_cc_impl.cc
-    debug_msg_source_raw_impl.cc
     ax25_encoder_mb_impl.cc
     ax25_decoder_bm_impl.cc
     qb50_deframer_impl.cc )
+
+if(${INCLUDE_DEBUG_BLOCKS})
+	list(APPEND satnogs_sources ${satnogs_debug_sources})
+endif()
 
 set(satnogs_sources "${satnogs_sources}" PARENT_SCOPE)
 if(NOT satnogs_sources)

--- a/lib/tcp_rigctl_msg_source_impl.cc
+++ b/lib/tcp_rigctl_msg_source_impl.cc
@@ -161,7 +161,7 @@ namespace gr
 	       * NOTE: Comparison for equality in floats is a bit tricky.
 	       * But here the get_freq_from_buf() will assign a 0.0 explicitly
 	       * if something goes wrong. For this reason it is safe to compare
-	       * the in-equality agains 0.0.
+	       * the in-equality against 0.0.
 	       */
 	      if (freq != 0.0) {
 		reported_freq = freq;

--- a/swig/CMakeLists.txt
+++ b/swig/CMakeLists.txt
@@ -57,9 +57,18 @@ GR_SWIG_INSTALL(TARGETS satnogs_swig DESTINATION ${GR_PYTHON_DIR}/satnogs)
 ########################################################################
 # Install swig .i files for development
 ########################################################################
+list(APPEND swig_files
+	satnogs_swig.i
+    ${CMAKE_CURRENT_BINARY_DIR}/satnogs_swig_doc.i
+)
+
+if(${INCLUDE_DEBUG_BLOCKS})
+	list(APPEND swig_files "satnogs_debug_swig.i")
+endif()
+
 install(
     FILES
-    satnogs_swig.i
+    ${swig_files}
     ${CMAKE_CURRENT_BINARY_DIR}/satnogs_swig_doc.i
     DESTINATION ${GR_INCLUDE_DIR}/satnogs/swig
 )

--- a/swig/satnogs_debug_swig.i
+++ b/swig/satnogs_debug_swig.i
@@ -1,0 +1,23 @@
+/* -*- c++ -*- */
+
+%include <typemaps.i>
+%include "gnuradio.i"			// the common stuff
+
+//load generated python docstrings
+%include "satnogs_swig_doc.i"
+
+%{
+#include "satnogs/morse_debug_source.h"
+#include "satnogs/debug_msg_source.h"
+#include "satnogs/debug_msg_source_raw.h"
+%}
+
+%include "satnogs/morse_debug_source.h"
+GR_SWIG_BLOCK_MAGIC2(satnogs, morse_debug_source);
+
+%include "satnogs/debug_msg_source.h"
+GR_SWIG_BLOCK_MAGIC2(satnogs, debug_msg_source);
+
+%include "satnogs/debug_msg_source_raw.h"
+GR_SWIG_BLOCK_MAGIC2(satnogs, debug_msg_source_raw);
+


### PR DESCRIPTION
The build systen now allows to enable/disable the blocks of the OOT
module that are used for development and debugging purposes.
