### PR TITLE
apps/scripts/satnogs_waterfall.gp: Add usage documentation

### DIFF
--- a/apps/scripts/satnogs_waterfall.gp
+++ b/apps/scripts/satnogs_waterfall.gp
@@ -16,7 +16,12 @@
 #
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <http://www.gnu.org/licenses/>
+
+# satnogs-waterfall.gp
+# Plot a waterfall diagramm from the output of the satnogs_waterfall_sink block.
 #
+# Usage:
+# gnuplot -e "inputfile='waterfall_sink.data'" -e "outfile='waterfall.png'" /usr/local/share/satnogs/scripts/satnogs_waterfall.gp
 
 reset
 if (!exists("height")) height=800


### PR DESCRIPTION
Since this waterfall sink is useful by itself (without satnogs), I added these short comments (not sure whether this place is appropriate).

Source: https://github.com/satnogs/satnogs-client/blob/68cbdb0812c63fa374ec5013320110126a3d96d5/satnogsclient/observer/observer.py