### PR TITLE
Fix possible bug in FSK decoder

### DIFF
--- a/lib/upsat_fsk_frame_acquisition_impl.cc
+++ b/lib/upsat_fsk_frame_acquisition_impl.cc
@@ -231,7 +231,7 @@ namespace gr
 	      d_decoded_bits = 0;
 	      if(d_shifting_byte == d_preamble[d_decoded_bytes]){
 		d_decoded_bytes++;
-		if(d_decoded_bytes == d_search_for_sync_thrhld){
+		if(d_decoded_bytes >= d_search_for_sync_thrhld){
 		  /* End of the preamble. It's time for the sync word */
 		  searching_sync_word();
 		}


### PR DESCRIPTION
In case the preamble and sync word length is 3 to 6, the variable d_search_for_sync_thrhld is initialized to 1. When the first preamble byte is found, the variable d_decoded_bytes becomes 1. If after 8 bits the next preamble byte is found,  d_decoded_bytes is increased to 2 in line 233. Then the statement if(d_decoded_bytes == d_search_for_sync_thrhld) will not be satisfied (d_decoded_bytes=2, d_search_for_sync_thrhld=1), although it should, and as a matter of fact it will not ever be satisfied, which will result in the code never start searching for the sync word.