### PR TITLE
fix rtlsdr sample rate for rpi

### DIFF
--- a/python/hw_settings.py
+++ b/python/hw_settings.py
@@ -46,5 +46,5 @@ hw_rx_settings = {'usrpb200' : {'rf_gain' : 50.0, 'if_gain' : 0.0,
                               'bb_gain' : 20.0, 'samp_rate' : 8e6,
                               'antenna' : '', 'dev_arg': 'hackrf'},
                   'rtlsdr' : {'rf_gain' : 32.8, 'if_gain' : 0.0,
-                              'bb_gain' : 0.0, 'samp_rate' : 1.5e6,
+                              'bb_gain' : 0.0, 'samp_rate' : 1e6,
                               'antenna' : '', 'dev_arg' : 'rtl'} }


### PR DESCRIPTION
1.5e6 is too high and causes timing clips in the raspberry pi. 1e6 was tested successully today and eliminates the clips.