### PR TITLE
Change NOAA output naming scheme

### DIFF
--- a/lib/noaa_apt_sink_impl.cc
+++ b/lib/noaa_apt_sink_impl.cc
@@ -92,19 +92,7 @@ namespace gr
     void
     noaa_apt_sink_impl::init_png ()
     {
-      /* check for the current UTC time */
-      std::chrono::system_clock::time_point p2 =
-          std::chrono::system_clock::now ();
-
-      char buffer[30];
-      std::time_t t2 = std::chrono::system_clock::to_time_t (p2);
-      struct tm * timeinfo;
-      timeinfo = std::gmtime (&t2);
-
-      std::strftime (buffer, 30, "%FT%H-%M-%S", timeinfo);
       std::string fn (d_filename_png);
-      fn.append("_");
-      fn.append(buffer);
       fn.append(".png");
       if (d_split) {
         d_images_per_frame = 2;


### PR DESCRIPTION
NOAA APT decoder will create a file without a timestamp. The
satnogs-client will be resposible to append the proper timestamp.
This change was necessary to avoid the time offset between the start of
the observation timestamp that the APT decoder appends to the filename
and the end of the observation that the client takes into account.