### PR TITLE
Remove unnecessary calculation from doppler correction block

### DIFF
--- a/lib/doppler_correction_cc_impl.cc
+++ b/lib/doppler_correction_cc_impl.cc
@@ -181,9 +181,6 @@ namespace gr
 	     * should continue using the predicted frequencies
 	     */
 	    if (d_corrections == d_corrections_per_sec) {
-	      d_doppler_fit_engine.predict_freqs (d_predicted_freqs,
-						  d_corrections_per_sec,
-						  d_update_period);
 	      d_corrections = 0;
 	    }
 	  }


### PR DESCRIPTION
I was reading through the code, and unless I'm missing something very obvious, this calculation is unnecessary since `d_predicted_freqs` won't change anyway.

I am not confident about this so please feel free to close if I'm wrong. Thanks!